### PR TITLE
Bump v0.1.7 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "flexvolume-drivers-psp"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "k8s-openapi",
  "kubewarden-policy-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flexvolume-drivers-psp"
-version = "0.1.5"
+version = "0.1.7"
 authors = ["Rafael Fernández López <ereslibre@ereslibre.es>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,16 +4,16 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.5
+version: 0.1.7
 name: flexvolume-drivers-psp
 displayName: Flexvolume Drivers Psp
-createdAt: 2023-03-21T11:57:55.995949483Z
+createdAt: 2023-07-07T19:11:23.16092291Z
 description: Replacement for the Kubernetes Pod Security Policy that controls the allowed `flexVolume` drivers
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/flexvolume-drivers-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/flexvolume-drivers-psp:v0.1.5
+  image: ghcr.io/kubewarden/policies/flexvolume-drivers-psp:v0.1.7
 keywords:
 - psp
 - container
@@ -22,13 +22,13 @@ keywords:
 - flex
 links:
 - name: policy
-  url: https://github.com/kubewarden/flexvolume-drivers-psp-policy/releases/download/v0.1.5/policy.wasm
+  url: https://github.com/kubewarden/flexvolume-drivers-psp-policy/releases/download/v0.1.7/policy.wasm
 - name: source
   url: https://github.com/kubewarden/flexvolume-drivers-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/flexvolume-drivers-psp:v0.1.5
+  kwctl pull ghcr.io/kubewarden/policies/flexvolume-drivers-psp:v0.1.7
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.1.6 policy version.        

Updates the Cargo and artifacthub files bumping the policy version to v0.1.6

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
